### PR TITLE
fix leaking VcsLogGraphTable instances from WindowService

### DIFF
--- a/src/main/java/org/jetbrains/research/refactorinsight/services/WindowService.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/services/WindowService.java
@@ -4,6 +4,8 @@ import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
+import com.intellij.vcs.log.ui.MainVcsLogUi;
 import com.intellij.vcs.log.ui.VcsLogInternalDataKeys;
 import com.intellij.vcs.log.ui.table.VcsLogGraphTable;
 import java.util.HashMap;
@@ -34,9 +36,12 @@ public class WindowService {
    * @param state true for selected, false for unselected
    */
   public void setSelected(@NotNull AnActionEvent e, boolean state) {
-    VcsLogGraphTable table = e.getData(VcsLogInternalDataKeys.MAIN_UI).getTable();
-    gitInfo.putIfAbsent(table, new GitWindow(e));
-    gitInfo.get(table).setSelected(state);
+    MainVcsLogUi ui = e.getData(VcsLogInternalDataKeys.MAIN_UI);
+    GitWindow gitWindow = gitInfo.computeIfAbsent(ui.getTable(), table -> {
+      Disposer.register(ui, () -> gitInfo.remove(ui.getTable()));
+      return new GitWindow(e);
+    });
+    gitWindow.setSelected(state);
   }
 
   public boolean isSelected(@NotNull AnActionEvent e) {


### PR DESCRIPTION
This commit removes the table from WindowService.gitInfo map when the corresponding VcsLogUi is disposed, so that the table object could be properly collected.

Additionally, putIfAbsent method is replaced by computeIfAbsent in order to avoid creating extra instances of GitWindow.

![image](https://user-images.githubusercontent.com/58706/88194949-17f70e00-cc48-11ea-87d7-6c36a9fddb63.png)