### PR TITLE
Load TimedVcsCommit instances instead of GitCommit

### DIFF
--- a/src/main/java/org/jetbrains/research/refactorinsight/data/RefactoringEntry.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/data/RefactoringEntry.java
@@ -10,7 +10,7 @@ import static org.refactoringminer.api.RefactoringType.PULL_UP_OPERATION;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
-import com.intellij.vcs.log.VcsCommitMetadata;
+import com.intellij.vcs.log.TimedVcsCommit;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,7 +82,7 @@ public class RefactoringEntry implements Serializable {
    * @param commit       current commit.
    * @return new refactoring entry.
    */
-  public static RefactoringEntry convert(List<Refactoring> refactorings, VcsCommitMetadata commit,
+  public static RefactoringEntry convert(List<Refactoring> refactorings, TimedVcsCommit commit,
                                          Project project) {
 
     RefactoringEntry entry =

--- a/src/main/java/org/jetbrains/research/refactorinsight/processors/CommitMiner.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/processors/CommitMiner.java
@@ -5,8 +5,7 @@ import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
-import com.intellij.vcs.log.VcsCommitMetadata;
-import git4idea.GitCommit;
+import com.intellij.vcs.log.TimedVcsCommit;
 import git4idea.repo.GitRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +32,7 @@ import org.refactoringminer.util.GitServiceImpl;
  * It mines a commit and updates the refactoring map with the data retrieved for that commit.
  * Consumes a git commit, calls RefactoringMiner and detects the refactorings for a commit.
  */
-public class CommitMiner implements Consumer<GitCommit> {
+public class CommitMiner implements Consumer<TimedVcsCommit> {
   private static final String progress = RefactorInsightBundle.message("progress");
   private final ExecutorService pool;
   private final Map<String, RefactoringEntry> map;
@@ -71,7 +70,7 @@ public class CommitMiner implements Consumer<GitCommit> {
    * @param project the current project
    * @param repository Git Repository
    */
-  public static void mineAtCommit(VcsCommitMetadata commit, Map<String, RefactoringEntry> map,
+  public static void mineAtCommit(TimedVcsCommit commit, Map<String, RefactoringEntry> map,
                                   Project project, Repository repository) {
     GitHistoryRefactoringMiner miner = new GitHistoryRefactoringMinerImpl();
     try {
@@ -94,7 +93,7 @@ public class CommitMiner implements Consumer<GitCommit> {
    *
    * @param gitCommit to be mined
    */
-  public void consume(GitCommit gitCommit) throws ProcessCanceledException {
+  public void consume(TimedVcsCommit gitCommit) throws ProcessCanceledException {
     String commitId = gitCommit.getId().asString();
 
     if (!map.containsKey(commitId)) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/processors/SingleCommitRefactoringTask.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/processors/SingleCommitRefactoringTask.java
@@ -10,6 +10,7 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Ref;
 import com.intellij.util.ExceptionUtil;
+import com.intellij.vcs.log.TimedVcsCommit;
 import com.intellij.vcs.log.VcsCommitMetadata;
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
@@ -115,8 +116,8 @@ public class SingleCommitRefactoringTask extends Task.Backgroundable {
    * or the current thread's indicator to be canceled.
    */
   private <T> void runWithCheckCanceled(@NotNull Future<T> future,
-                                               @NotNull final ProgressIndicator indicator,
-                                               VcsCommitMetadata commit, Project project) throws
+                                        @NotNull final ProgressIndicator indicator,
+                                        TimedVcsCommit commit, Project project) throws
       ExecutionException {
     int timeout = 6000;
     while (timeout > 0) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/services/MiningService.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/services/MiningService.java
@@ -159,7 +159,7 @@ public class MiningService implements PersistentStateComponent<MiningService.MyS
             try {
               String logArgs = "--max-count=" + limit;
               progressIndicator.checkCanceled();
-              GitHistoryUtils.loadDetails(repository.getProject(), repository.getRoot(),
+              GitHistoryUtils.loadTimedCommits(repository.getProject(), repository.getRoot(),
                   miner, logArgs);
               progressIndicator.checkCanceled();
             } catch (Exception exception) {


### PR DESCRIPTION
Loading GitCommit objects could be time and memory consuming, so it's preferable to load TimedVcsCommit objects as they contain all the required information.