### PR TITLE
Do not rely on components hierarchy for getting VcsLogChangeBrowser from the log tab

### DIFF
--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -10,33 +10,26 @@ import com.intellij.openapi.wm.ToolWindowAnchor;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.Gray;
 import com.intellij.ui.JBSplitter;
-import com.intellij.ui.OnePixelSplitter;
 import com.intellij.ui.components.JBLabel;
-import com.intellij.ui.components.JBLoadingPanel;
 import com.intellij.ui.components.JBPanel;
 import com.intellij.ui.components.JBScrollPane;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.treeStructure.Tree;
-import com.intellij.util.ui.components.BorderLayoutPanel;
+import com.intellij.util.ui.UIUtil;
 import com.intellij.vcs.log.data.VcsLogData;
 import com.intellij.vcs.log.impl.VcsLogManager;
 import com.intellij.vcs.log.impl.VcsProjectLog;
 import com.intellij.vcs.log.ui.MainVcsLogUi;
-import com.intellij.vcs.log.ui.frame.MainFrame;
 import com.intellij.vcs.log.ui.frame.VcsLogChangesBrowser;
 import com.intellij.vcs.log.visible.filters.VcsLogFilterObject;
 import icons.RefactorInsightIcons;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.JComponent;
-import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreePath;
@@ -162,19 +155,8 @@ public class RefactoringHistoryToolbar {
     splitter.setSecondComponent(mainComponent);
     openLogTab.jumpToHash(info.getCommitId());
 
-    JBSplitter splitter1 = (JBSplitter) mainComponent.getComponent(0);
-
-    BorderLayoutPanel splitter2 = (BorderLayoutPanel) splitter1.getFirstComponent();
-
-    OnePixelSplitter panel = (OnePixelSplitter) splitter2.getComponent(1);
-    MainFrame mainFrame = (MainFrame) panel.getComponent(2);
-
-    OnePixelSplitter splitter3 = (OnePixelSplitter) mainFrame.getComponent(0);
-    OnePixelSplitter splitter4 = (OnePixelSplitter) splitter3.getComponent(2);
-    JBLoadingPanel panel1 = (JBLoadingPanel) splitter4.getComponent(1);
-    JComponent loadingDecorator = (JComponent) panel1.getComponent(0);
-    JPanel panel2 = (JPanel) loadingDecorator.getComponent(0);
-    VcsLogChangesBrowser browser = (VcsLogChangesBrowser) panel2.getComponent(0);
+    VcsLogChangesBrowser browser = Objects.requireNonNull(UIUtil.findComponentOfType(openLogTab.getMainComponent(),
+            VcsLogChangesBrowser.class));
     ((ActionButton) browser.getToolbar().getComponent().getComponent(1)).click();
   }
 


### PR DESCRIPTION
The hierarchy of components in the log tab is an implementation detail and could change at any moment, so the code could end up broken. It's better to use the "findComponentOfType" method that should work as log as the component of the provided type is present.

I did not understand what `((ActionButton) browser.getToolbar().getComponent().getComponent(1)).click()` does, so I did not touch it. But I'm sure this also could be simplified.