### PR TITLE
Fix Vcs Log Api Usages in RefactoringHistoryToolbar

### DIFF
--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.JComponent;
 import javax.swing.SwingConstants;
@@ -148,7 +149,9 @@ public class RefactoringHistoryToolbar {
       return;
     }
 
-    openLogTab = logManager.createLogUi(logManager.getMainLogUiFactory("method history", null), VcsLogManager.LogWindowKind.STANDALONE);
+    String logId = "method history " + UUID.randomUUID();
+    openLogTab = logManager.createLogUi(logManager.getMainLogUiFactory(logId, null),
+            VcsLogManager.LogWindowKind.STANDALONE);
 
     Utils.add(openLogTab);
     JComponent mainComponent = openLogTab.getMainComponent();

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -20,6 +20,7 @@ import com.intellij.util.ui.UIUtil;
 import com.intellij.vcs.log.impl.VcsLogManager;
 import com.intellij.vcs.log.impl.VcsProjectLog;
 import com.intellij.vcs.log.ui.MainVcsLogUi;
+import com.intellij.vcs.log.ui.VcsLogPanel;
 import com.intellij.vcs.log.ui.frame.VcsLogChangesBrowser;
 import icons.RefactorInsightIcons;
 import java.awt.GridLayout;
@@ -153,7 +154,8 @@ public class RefactoringHistoryToolbar {
     JComponent mainComponent = openLogTab.getMainComponent();
     mainComponent.setAutoscrolls(true);
     mainComponent.setSize(splitter.getSecondComponent().getSize());
-    splitter.setSecondComponent(mainComponent);
+    splitter.setSecondComponent(new VcsLogPanel(logManager, openLogTab));
+
     openLogTab.jumpToHash(info.getCommitId());
 
     VcsLogChangesBrowser browser = Objects.requireNonNull(UIUtil.findComponentOfType(openLogTab.getMainComponent(),

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -17,12 +17,10 @@ import com.intellij.ui.content.Content;
 import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.util.ui.UIUtil;
-import com.intellij.vcs.log.data.VcsLogData;
 import com.intellij.vcs.log.impl.VcsLogManager;
 import com.intellij.vcs.log.impl.VcsProjectLog;
 import com.intellij.vcs.log.ui.MainVcsLogUi;
 import com.intellij.vcs.log.ui.frame.VcsLogChangesBrowser;
-import com.intellij.vcs.log.visible.filters.VcsLogFilterObject;
 import icons.RefactorInsightIcons;
 import java.awt.GridLayout;
 import java.awt.event.MouseAdapter;
@@ -51,8 +49,6 @@ import org.jetbrains.research.refactorinsight.utils.Utils;
  */
 public class RefactoringHistoryToolbar {
 
-  private final VcsLogManager.VcsLogUiFactory<? extends MainVcsLogUi> factory;
-
   private MainVcsLogUi openLogTab;
   private ToolWindowManager toolWindowManager;
   private ToolWindow toolWindow;
@@ -68,8 +64,6 @@ public class RefactoringHistoryToolbar {
     this.project = project;
     toolWindowManager = ToolWindowManager.getInstance(project);
     Utils.manager = toolWindowManager;
-    factory = VcsProjectLog.getInstance(project).getLogManager()
-        .getMainLogUiFactory("method history", VcsLogFilterObject.collection());
     toolWindow =
         toolWindowManager.registerToolWindow(RefactorInsightBundle.message("history"),
             true, ToolWindowAnchor.BOTTOM);
@@ -148,9 +142,12 @@ public class RefactoringHistoryToolbar {
   }
 
   private void showLogTab(RefactoringInfo info, JBSplitter splitter) {
-    VcsLogData data = VcsProjectLog.getInstance(project).getLogManager().getDataManager();
+    VcsLogManager logManager = VcsProjectLog.getInstance(project).getLogManager();
+    if (logManager == null) {
+      return;
+    }
 
-    openLogTab = factory.createLogUi(project, data);
+    openLogTab = logManager.createLogUi(logManager.getMainLogUiFactory("method history", null), VcsLogManager.LogWindowKind.STANDALONE);
 
     Utils.add(openLogTab);
     JComponent mainComponent = openLogTab.getMainComponent();

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -51,7 +51,6 @@ import org.jetbrains.research.refactorinsight.utils.Utils;
  */
 public class RefactoringHistoryToolbar {
 
-  private MainVcsLogUi openLogTab;
   private ToolWindowManager toolWindowManager;
   private ToolWindow toolWindow;
   private Project project;
@@ -150,7 +149,7 @@ public class RefactoringHistoryToolbar {
     }
 
     String logId = "method history " + UUID.randomUUID();
-    openLogTab = logManager.createLogUi(logManager.getMainLogUiFactory(logId, null),
+    MainVcsLogUi openLogTab = logManager.createLogUi(logManager.getMainLogUiFactory(logId, null),
             VcsLogManager.LogWindowKind.STANDALONE);
 
     Utils.add(openLogTab);

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -5,6 +5,7 @@ import com.intellij.openapi.actionSystem.impl.ActionButton;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowAnchor;
 import com.intellij.openapi.wm.ToolWindowManager;
@@ -152,11 +153,15 @@ public class RefactoringHistoryToolbar {
     MainVcsLogUi openLogTab = logManager.createLogUi(logManager.getMainLogUiFactory(logId, null),
             VcsLogManager.LogWindowKind.STANDALONE);
 
-    Utils.add(openLogTab);
     JComponent mainComponent = openLogTab.getMainComponent();
     mainComponent.setAutoscrolls(true);
     mainComponent.setSize(splitter.getSecondComponent().getSize());
     splitter.setSecondComponent(new VcsLogPanel(logManager, openLogTab));
+
+    Utils.disposeWithVcsLogManager(project, () -> {
+      setSecondComponent(splitter);
+      Disposer.dispose(openLogTab);
+    });
 
     openLogTab.jumpToHash(info.getCommitId());
 

--- a/src/main/java/org/jetbrains/research/refactorinsight/utils/Utils.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/utils/Utils.java
@@ -14,6 +14,8 @@ import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.LocalFilePath;
 import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.vcs.log.impl.VcsLogManager;
+import com.intellij.vcs.log.impl.VcsProjectLog;
 import git4idea.GitContentRevision;
 import git4idea.GitRevisionNumber;
 import git4idea.repo.GitRepository;
@@ -30,6 +32,8 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.research.refactorinsight.data.RefactoringEntry;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.data.RefactoringLine;
@@ -307,5 +311,20 @@ public class Utils {
         .map(Type::getTypeName)
     ).collect(Collectors.toList()))
         .hashCode();
+  }
+
+  public static void disposeWithVcsLogManager(@NotNull Project project, @NotNull Disposable disposable) {
+    Disposable connectionDisposable = Disposer.newDisposable();
+    project.getMessageBus().connect(connectionDisposable).subscribe(VcsProjectLog.VCS_PROJECT_LOG_CHANGED, new VcsProjectLog.ProjectLogListener() {
+      @Override
+      public void logCreated(@NotNull VcsLogManager manager) {
+      }
+
+      @Override
+      public void logDisposed(@NotNull VcsLogManager manager) {
+        Disposer.dispose(connectionDisposable);
+        Disposer.dispose(disposable);
+      }
+    });
   }
 }


### PR DESCRIPTION
This PR fixes usages of Vcs Log api to correctly create and dispose Log panel in the `RefactoringHistoryToolbar`. This allows creation, refresh, actions, and dispose working properly for the tab.