### PR TITLE
Remove usage of deprecated method jumpToHash

### DIFF
--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/RefactoringHistoryToolbar.java
@@ -163,7 +163,7 @@ public class RefactoringHistoryToolbar {
       Disposer.dispose(openLogTab);
     });
 
-    openLogTab.jumpToHash(info.getCommitId());
+    openLogTab.getVcsLog().jumpToReference(info.getCommitId());
 
     VcsLogChangesBrowser browser = Objects.requireNonNull(UIUtil.findComponentOfType(openLogTab.getMainComponent(),
             VcsLogChangesBrowser.class));


### PR DESCRIPTION
Method `com.intellij.vcs.log.ui.VcsLogUiEx#jumpToHash` got deprecated in https://github.com/JetBrains/intellij-community/commit/ef37b72eac9dbec7cf86a55354e62c1f33efbc07.