### PR TITLE
Refactoring types grouping. Closes #10

### DIFF
--- a/src/main/java/org/jetbrains/research/refactorinsight/pullrequests/PRFileEditor.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/pullrequests/PRFileEditor.java
@@ -25,6 +25,7 @@ import org.jetbrains.research.refactorinsight.RefactorInsightBundle;
 import org.jetbrains.research.refactorinsight.data.RefactoringEntry;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.services.MiningService;
+import org.jetbrains.research.refactorinsight.ui.tree.Node;
 import org.jetbrains.research.refactorinsight.ui.tree.TreeUtils;
 import org.jetbrains.research.refactorinsight.ui.tree.renderers.MainCellRenderer;
 import org.jetbrains.research.refactorinsight.ui.windows.DiffWindow;
@@ -165,8 +166,7 @@ public class PRFileEditor extends FileEditorBase {
             }
             DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
             if (node.isLeaf()) {
-              RefactoringInfo info = (RefactoringInfo)
-                  node.getUserObjectPath()[1];
+              RefactoringInfo info = ((Node) node.getUserObject()).getInfo();
               final Collection<Change> changes = Optional.ofNullable(commitsDetails.get(info.getCommitId()))
                   .map(VcsFullCommitDetails::getChanges).orElse(new ArrayList<>());
               if (changes.size() != 0) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/DisplayedGroup.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/DisplayedGroup.java
@@ -7,7 +7,6 @@ public enum DisplayedGroup {
   METHOD,
   CLASS,
   VARIABLE,
-  ABSTRACT,
   PACKAGE;
 
   @NotNull
@@ -18,11 +17,10 @@ public enum DisplayedGroup {
       case ATTRIBUTE:
       case VARIABLE:
         return VARIABLE;
+      case ABSTRACT:
       case INTERFACE:
       case CLASS:
         return CLASS;
-      case ABSTRACT:
-        return ABSTRACT;
       case PACKAGE:
         return PACKAGE;
       default:

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/DisplayedGroup.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/DisplayedGroup.java
@@ -9,6 +9,9 @@ public enum DisplayedGroup {
   VARIABLE,
   PACKAGE;
 
+  /**
+   * Get displayed type of refactoring from internal representation.
+   */
   @NotNull
   public static DisplayedGroup fromInternalGroup(@NotNull Group group) {
     switch (group) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/DisplayedGroup.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/DisplayedGroup.java
@@ -1,0 +1,32 @@
+package org.jetbrains.research.refactorinsight.ui.tree;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.research.refactorinsight.data.Group;
+
+public enum DisplayedGroup {
+  METHOD,
+  CLASS,
+  VARIABLE,
+  ABSTRACT,
+  PACKAGE;
+
+  @NotNull
+  public static DisplayedGroup fromInternalGroup(@NotNull Group group) {
+    switch (group) {
+      case METHOD:
+        return METHOD;
+      case ATTRIBUTE:
+      case VARIABLE:
+        return VARIABLE;
+      case INTERFACE:
+      case CLASS:
+        return CLASS;
+      case ABSTRACT:
+        return ABSTRACT;
+      case PACKAGE:
+        return PACKAGE;
+      default:
+        throw new IllegalStateException("Unexpected value: " + group);
+    }
+  }
+}

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/Node.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/Node.java
@@ -8,6 +8,12 @@ public class Node {
   private final String content;
   private final RefactoringInfo info;
 
+  /**
+   * Constructing the node of the rendering tree.
+   * @param type Node type in tree
+   * @param content Main content of node (optional)
+   * @param info info of associated refactoring
+   */
   public Node(NodeType type, String content, RefactoringInfo info) {
     this.type = type;
     this.content = content;

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/Node.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/Node.java
@@ -1,13 +1,17 @@
 package org.jetbrains.research.refactorinsight.ui.tree;
 
+import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
+
 public class Node {
 
-  private NodeType type;
-  private String content;
+  private final NodeType type;
+  private final String content;
+  private final RefactoringInfo info;
 
-  public Node(NodeType type, String content) {
+  public Node(NodeType type, String content, RefactoringInfo info) {
     this.type = type;
     this.content = content;
+    this.info = info;
   }
 
   public NodeType getType() {
@@ -16,5 +20,9 @@ public class Node {
 
   public String getContent() {
     return content;
+  }
+
+  public RefactoringInfo getInfo() {
+    return info;
   }
 }

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/NodeType.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/NodeType.java
@@ -1,6 +1,7 @@
 package org.jetbrains.research.refactorinsight.ui.tree;
 
 public enum NodeType {
+  TYPE,
   DETAILS,
   NAME,
   ELEMENTS

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/NodeType.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/NodeType.java
@@ -1,6 +1,7 @@
 package org.jetbrains.research.refactorinsight.ui.tree;
 
 public enum NodeType {
+  GROUP,
   TYPE,
   DETAILS,
   NAME,

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
@@ -75,7 +75,7 @@ public class TreeUtils {
    */
   public static DefaultMutableTreeNode makeNameNode(RefactoringInfo info) {
     return new DefaultMutableTreeNode(
-        new Node(NodeType.NAME, StringUtils.getDisplayableName(info)));
+        new Node(NodeType.NAME, StringUtils.getDisplayableName(info), info));
 
   }
 
@@ -88,7 +88,7 @@ public class TreeUtils {
     final String displayableDetails =
         getDisplayableDetails(info.getDetailsBefore(), info.getDetailsAfter());
     if (displayableDetails != null && displayableDetails.length() > 0) {
-      return new DefaultMutableTreeNode(new Node(NodeType.DETAILS, displayableDetails));
+      return new DefaultMutableTreeNode(new Node(NodeType.DETAILS, displayableDetails, info));
     } else {
       return null;
     }
@@ -102,7 +102,7 @@ public class TreeUtils {
     String displayableElement =
         getDisplayableElement(info.getElementBefore(), info.getElementAfter());
     if (displayableElement != null) {
-      return new DefaultMutableTreeNode(new Node(NodeType.ELEMENTS, displayableElement));
+      return new DefaultMutableTreeNode(new Node(NodeType.ELEMENTS, displayableElement, info));
     }
     return null;
   }

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
@@ -73,9 +73,9 @@ public class TreeUtils {
   /**
    * Creates a node based on the nameBefore & nameAfter attributes.
    */
-  public static DefaultMutableTreeNode makeNameNode(RefactoringInfo refactoringInfo) {
+  public static DefaultMutableTreeNode makeNameNode(RefactoringInfo info) {
     return new DefaultMutableTreeNode(
-        new Node(NodeType.NAME, StringUtils.getDisplayableName(refactoringInfo)));
+        new Node(NodeType.NAME, StringUtils.getDisplayableName(info)));
 
   }
 
@@ -98,9 +98,9 @@ public class TreeUtils {
    * Adds leaves for refactorings where the element
    * is not null.
    */
-  public static DefaultMutableTreeNode makeLeafNode(RefactoringInfo ref) {
+  public static DefaultMutableTreeNode makeLeafNode(RefactoringInfo info) {
     String displayableElement =
-        getDisplayableElement(ref.getElementBefore(), ref.getElementAfter());
+        getDisplayableElement(info.getElementBefore(), info.getElementAfter());
     if (displayableElement != null) {
       return new DefaultMutableTreeNode(new Node(NodeType.ELEMENTS, displayableElement));
     }

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
@@ -5,7 +5,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.tree.DefaultMutableTreeNode;
-import org.jetbrains.research.refactorinsight.data.Group;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.utils.StringUtils;
 
@@ -171,14 +170,13 @@ public class TreeUtils {
    * @return Swing Tree visualisation of refactorings in this entry.
    */
   public static Tree buildTree(List<RefactoringInfo> refactorings) {
-    Map<Group, DefaultMutableTreeNode> groups = new EnumMap<>(Group.class);
+    Map<DisplayedGroup, DefaultMutableTreeNode> groups = new EnumMap<>(DisplayedGroup.class);
     DefaultMutableTreeNode root =
         new DefaultMutableTreeNode(refactorings.isEmpty() ? "" : refactorings.get(0).getCommitId());
     refactorings.forEach(info -> {
       if (!info.isHidden()) {
-        groups.computeIfAbsent(info.getGroup(), group -> {
-          DefaultMutableTreeNode groupNode =
-              new DefaultMutableTreeNode(new Node(NodeType.GROUP, null, info));
+        groups.computeIfAbsent(DisplayedGroup.fromInternalGroup(info.getGroup()), group -> {
+          DefaultMutableTreeNode groupNode = new DefaultMutableTreeNode(new Node(NodeType.GROUP, null, info));
           root.add(groupNode);
           return groupNode;
         }).add(makeNode(info));

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
@@ -53,7 +53,7 @@ public class TreeUtils {
    * @return the node.
    */
   public static DefaultMutableTreeNode makeNode(RefactoringInfo info) {
-    DefaultMutableTreeNode node = new DefaultMutableTreeNode(info);
+    DefaultMutableTreeNode node = new DefaultMutableTreeNode(new Node(NodeType.TYPE, null, info));
 
     DefaultMutableTreeNode detailsNode = makeDetailsNode(info);
     DefaultMutableTreeNode nameNode = makeNameNode(info);

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/TreeUtils.java
@@ -1,8 +1,11 @@
 package org.jetbrains.research.refactorinsight.ui.tree;
 
 import com.intellij.ui.treeStructure.Tree;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import javax.swing.tree.DefaultMutableTreeNode;
+import org.jetbrains.research.refactorinsight.data.Group;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.utils.StringUtils;
 
@@ -168,11 +171,17 @@ public class TreeUtils {
    * @return Swing Tree visualisation of refactorings in this entry.
    */
   public static Tree buildTree(List<RefactoringInfo> refactorings) {
+    Map<Group, DefaultMutableTreeNode> groups = new EnumMap<>(Group.class);
     DefaultMutableTreeNode root =
         new DefaultMutableTreeNode(refactorings.isEmpty() ? "" : refactorings.get(0).getCommitId());
-    refactorings.forEach(r -> {
-      if (!r.isHidden()) {
-        root.add(makeNode(r));
+    refactorings.forEach(info -> {
+      if (!info.isHidden()) {
+        groups.computeIfAbsent(info.getGroup(), group -> {
+          DefaultMutableTreeNode groupNode =
+              new DefaultMutableTreeNode(new Node(NodeType.GROUP, null, info));
+          root.add(groupNode);
+          return groupNode;
+        }).add(makeNode(info));
       }
     });
     Tree tree = new Tree(root);

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/CellIconFactory.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/CellIconFactory.java
@@ -33,6 +33,9 @@ public class CellIconFactory {
     map.put(Group.VARIABLE, new VariableHandler());
   }
 
+  /**
+   * Get icon from node type and info.
+   */
   public Icon create(RefactoringInfo info, Node node) {
     switch (node.getType()) {
       case GROUP:
@@ -55,8 +58,8 @@ public class CellIconFactory {
       case PACKAGE:
         return AllIcons.Nodes.Package;
       default:
-        throw new IllegalStateException("Unexpected value: " +
-            DisplayedGroup.fromInternalGroup(info.getGroup()));
+        throw new IllegalStateException("Unexpected value: "
+            + DisplayedGroup.fromInternalGroup(info.getGroup()));
     }
   }
 }

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/CellIconFactory.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/CellIconFactory.java
@@ -1,9 +1,13 @@
 package org.jetbrains.research.refactorinsight.ui.tree.renderers;
 
-import java.util.HashMap;
+import java.util.EnumMap;
+import java.util.Map;
 import javax.swing.Icon;
+import com.intellij.icons.AllIcons;
+import icons.RefactorInsightIcons;
 import org.jetbrains.research.refactorinsight.data.Group;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
+import org.jetbrains.research.refactorinsight.ui.tree.DisplayedGroup;
 import org.jetbrains.research.refactorinsight.ui.tree.Node;
 import org.jetbrains.research.refactorinsight.ui.tree.renderers.handlers.AbstractClassHandler;
 import org.jetbrains.research.refactorinsight.ui.tree.renderers.handlers.AttributeHandler;
@@ -14,7 +18,7 @@ import org.jetbrains.research.refactorinsight.ui.tree.renderers.handlers.Package
 import org.jetbrains.research.refactorinsight.ui.tree.renderers.handlers.VariableHandler;
 
 public class CellIconFactory {
-  HashMap<Group, IconHandler> map = new HashMap<>();
+  private final Map<Group, IconHandler> map = new EnumMap<>(Group.class);
 
   /**
    * Fills map with all types of handlers.
@@ -30,7 +34,29 @@ public class CellIconFactory {
   }
 
   public Icon create(RefactoringInfo info, Node node) {
-    return map.get(info.getGroup()).getIcon(info, node);
+    switch (node.getType()) {
+      case GROUP:
+        return groupIcon(info);
+      case TYPE:
+        return RefactorInsightIcons.node;
+      default:
+        return map.get(info.getGroup()).getIcon(info, node);
+    }
+  }
 
+  private Icon groupIcon(RefactoringInfo info) {
+    switch (DisplayedGroup.fromInternalGroup(info.getGroup())) {
+      case METHOD:
+        return AllIcons.Nodes.Method;
+      case CLASS:
+        return AllIcons.Nodes.Class;
+      case VARIABLE:
+        return AllIcons.Nodes.Variable;
+      case PACKAGE:
+        return AllIcons.Nodes.Package;
+      default:
+        throw new IllegalStateException("Unexpected value: " +
+            DisplayedGroup.fromInternalGroup(info.getGroup()));
+    }
   }
 }

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/HistoryToolbarRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/HistoryToolbarRenderer.java
@@ -7,6 +7,7 @@ import com.intellij.util.text.JBDateFormat;
 import javax.swing.Icon;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
+import icons.RefactorInsightIcons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.ui.tree.Node;
@@ -24,7 +25,16 @@ public class HistoryToolbarRenderer extends ColoredTreeCellRenderer {
    * @return the refactoring info parent.
    */
   public static RefactoringInfo getRefactoringInfo(DefaultMutableTreeNode node) {
-    return ((Node) node.getUserObject()).getInfo();
+    RefactoringInfo info = null;
+    if (node.getUserObject() instanceof Node) {
+      info = ((Node) node.getUserObject()).getInfo();
+    } else if (node.getUserObjectPath()[1] instanceof RefactoringInfo) {
+      info = (RefactoringInfo) node.getUserObjectPath()[1];
+    } else if (node.getUserObjectPath().length > 3
+          && node.getUserObjectPath()[3] instanceof RefactoringInfo) {
+        info = (RefactoringInfo) node.getUserObjectPath()[3];
+    }
+    return info;
   }
 
   @Override
@@ -46,6 +56,9 @@ public class HistoryToolbarRenderer extends ColoredTreeCellRenderer {
       } else {
         append(object.getContent());
       }
+    } else if (node.getUserObject() instanceof RefactoringInfo) {
+      append(info.getName());
+      icon = RefactorInsightIcons.node;
     } else if (node.getParent().equals(node.getRoot())) {
       append(node.toString(), SimpleTextAttributes.GRAY_ATTRIBUTES);
     } else {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/HistoryToolbarRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/HistoryToolbarRenderer.java
@@ -4,13 +4,13 @@ import com.intellij.icons.AllIcons;
 import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.text.JBDateFormat;
-import icons.RefactorInsightIcons;
 import javax.swing.Icon;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.ui.tree.Node;
+import org.jetbrains.research.refactorinsight.ui.tree.NodeType;
 
 public class HistoryToolbarRenderer extends ColoredTreeCellRenderer {
 
@@ -41,10 +41,11 @@ public class HistoryToolbarRenderer extends ColoredTreeCellRenderer {
     if (node.getUserObject() instanceof Node) {
       final Node object = (Node) node.getUserObject();
       icon = factory.create(info, object);
-      append(object.getContent());
-    } else if (node.getUserObject() instanceof RefactoringInfo) {
-      append(info.getName());
-      icon = RefactorInsightIcons.node;
+      if (object.getType() == NodeType.TYPE) {
+        append(info.getName());
+      } else {
+        append(object.getContent());
+      }
     } else if (node.getParent().equals(node.getRoot())) {
       append(node.toString(), SimpleTextAttributes.GRAY_ATTRIBUTES);
     } else {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/HistoryToolbarRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/HistoryToolbarRenderer.java
@@ -24,16 +24,7 @@ public class HistoryToolbarRenderer extends ColoredTreeCellRenderer {
    * @return the refactoring info parent.
    */
   public static RefactoringInfo getRefactoringInfo(DefaultMutableTreeNode node) {
-    RefactoringInfo info = null;
-    if (node.getUserObjectPath()[1] instanceof RefactoringInfo) {
-      info = (RefactoringInfo) node.getUserObjectPath()[1];
-    } else {
-      if (node.getUserObjectPath().length > 3
-          && node.getUserObjectPath()[3] instanceof RefactoringInfo) {
-        info = (RefactoringInfo) node.getUserObjectPath()[3];
-      }
-    }
-    return info;
+    return ((Node) node.getUserObject()).getInfo();
   }
 
   @Override

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
@@ -24,7 +24,7 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
                                     boolean expanded, boolean leaf, int row, boolean hasFocus) {
 
     DefaultMutableTreeNode node = (DefaultMutableTreeNode) value;
-    if (node.equals(node.getRoot())) {
+    if (node.isRoot()) {
       return;
     }
 
@@ -32,7 +32,11 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
     RefactoringInfo info = object.getInfo();
     Icon icon = factory.create(info, object);
 
-    if (object.getType() == NodeType.TYPE) {
+    if (object.getType() == NodeType.GROUP) {
+      String groupName = info.getGroup().toString();
+      String capitalizedName = groupName.substring(0, 1).toUpperCase() + groupName.substring(1).toLowerCase();
+      append(capitalizedName, SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
+    } else if (object.getType() == NodeType.TYPE) {
       append(info.getName(), SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
       int size = info.getIncludingRefactorings().size();
       if (size > 0) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
@@ -2,8 +2,6 @@ package org.jetbrains.research.refactorinsight.ui.tree.renderers;
 
 import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.SimpleTextAttributes;
-import icons.RefactorInsightIcons;
-import javax.swing.Icon;
 import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +29,7 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
 
     Node object = (Node) node.getUserObject();
     RefactoringInfo info = object.getInfo();
-    Icon icon = factory.create(info, object);
+    setIcon(factory.create(info, object));
 
     if (object.getType() == NodeType.GROUP) {
       String groupName = DisplayedGroup.fromInternalGroup(info.getGroup()).toString();
@@ -45,7 +43,6 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
                 .toString().replace("[", "").replace("]", ""),
             SimpleTextAttributes.GRAY_ATTRIBUTES);
       }
-      icon = RefactorInsightIcons.node;
     } else if (leaf) {
       append((info.getLineMarkings().size() > 0
               ? ((info.getLineMarkings().get(0).getRightStart() + 1) + " ") : ""),
@@ -56,7 +53,6 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
     } else {
       append(object.getContent());
     }
-    setIcon(icon);
   }
 
 }

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
@@ -9,6 +9,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.ui.tree.Node;
+import org.jetbrains.research.refactorinsight.ui.tree.NodeType;
 
 public class MainCellRenderer extends ColoredTreeCellRenderer {
 
@@ -27,15 +28,11 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
       return;
     }
 
-    RefactoringInfo info = (RefactoringInfo) node.getUserObjectPath()[1];
-    Icon icon = null;
-    Node object = null;
+    Node object = (Node) node.getUserObject();
+    RefactoringInfo info = object.getInfo();
+    Icon icon = factory.create(info, object);
 
-    if (node.getUserObject() instanceof Node) {
-      object = (Node) node.getUserObject();
-      icon = factory.create(info, object);
-    }
-    if (node.getUserObject() instanceof RefactoringInfo) {
+    if (object.getType() == NodeType.TYPE) {
       append(info.getName(), SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
       int size = info.getIncludingRefactorings().size();
       if (size > 0) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/tree/renderers/MainCellRenderer.java
@@ -8,6 +8,7 @@ import javax.swing.JTree;
 import javax.swing.tree.DefaultMutableTreeNode;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
+import org.jetbrains.research.refactorinsight.ui.tree.DisplayedGroup;
 import org.jetbrains.research.refactorinsight.ui.tree.Node;
 import org.jetbrains.research.refactorinsight.ui.tree.NodeType;
 
@@ -33,7 +34,7 @@ public class MainCellRenderer extends ColoredTreeCellRenderer {
     Icon icon = factory.create(info, object);
 
     if (object.getType() == NodeType.GROUP) {
-      String groupName = info.getGroup().toString();
+      String groupName = DisplayedGroup.fromInternalGroup(info.getGroup()).toString();
       String capitalizedName = groupName.substring(0, 1).toUpperCase() + groupName.substring(1).toLowerCase();
       append(capitalizedName, SimpleTextAttributes.REGULAR_BOLD_ATTRIBUTES);
     } else if (object.getType() == NodeType.TYPE) {

--- a/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/GitWindow.java
+++ b/src/main/java/org/jetbrains/research/refactorinsight/ui/windows/GitWindow.java
@@ -32,6 +32,7 @@ import org.jetbrains.research.refactorinsight.data.RefactoringEntry;
 import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
 import org.jetbrains.research.refactorinsight.services.MiningService;
 import org.jetbrains.research.refactorinsight.RefactorInsightBundle;
+import org.jetbrains.research.refactorinsight.ui.tree.Node;
 import org.jetbrains.research.refactorinsight.ui.tree.TreeUtils;
 import org.jetbrains.research.refactorinsight.ui.tree.renderers.MainCellRenderer;
 
@@ -147,8 +148,7 @@ public class GitWindow {
           }
           DefaultMutableTreeNode node = (DefaultMutableTreeNode) path.getLastPathComponent();
           if (node.isLeaf()) {
-            RefactoringInfo info = (RefactoringInfo)
-                node.getUserObjectPath()[1];
+            RefactoringInfo info = ((Node) node.getUserObject()).getInfo();
 
             DiffWindow.showDiff(table.getModel().getFullDetails(index)
                                     .getChanges(0), info, project, entry.getRefactorings());


### PR DESCRIPTION
Description of associated refactorings:

1. Added RefactoringInfo to node fields because searching it on the path to root is not safe and probably not good design point.
2. Moved more logic to cell icon factory because group level need new logic and it is better to encapsulate it.