### PR TITLE
Update commons-text dependency to 1.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation("org.eclipse.jgit:org.eclipse.jgit:5.2.1.201812262042-r")
     implementation("org.slf4j:slf4j-log4j12:1.7.7")
     implementation("org.eclipse.jdt:org.eclipse.jdt.core:3.16.0")
-    implementation("org.apache.commons:commons-text:1.6")
+    implementation("org.apache.commons:commons-text:1.10.0")
     implementation("org.kohsuke:github-api:1.95")
     implementation(group = "com.github.tsantalis", name = "refactoring-miner", version = "2.0")
     testImplementation("junit:junit:4.13")


### PR DESCRIPTION
Update `commons-text `dependency to 1.10 due to security vulnerability in the used version (1.6).