### PR TITLE
Updated visualization of Inline Variable refactoring

### DIFF
--- a/java-impl/src/main/java/org/jetbrains/research/refactorinsight/data/variables/InlineVariableJavaHandler.java
+++ b/java-impl/src/main/java/org/jetbrains/research/refactorinsight/data/variables/InlineVariableJavaHandler.java
@@ -14,13 +14,23 @@ public class InlineVariableJavaHandler extends JavaRefactoringHandler {
     public RefactoringInfo specify(Refactoring refactoring, RefactoringInfo info) {
         InlineVariableRefactoring ref = (InlineVariableRefactoring) refactoring;
 
-        ref.getReferences().forEach( reference ->
-                info.addMarking(
-                        createCodeRangeFromJava(ref.getVariableDeclaration().codeRange()),
-                        createCodeRangeFromJava(reference.getFragment2().codeRange()),
-                        true
-                )
-        );
+        if (ref.getSubExpressionMappings().isEmpty()) {
+            ref.getReferences().forEach(reference ->
+                    info.addMarking(
+                            createCodeRangeFromJava(ref.getVariableDeclaration().codeRange()),
+                            createCodeRangeFromJava(reference.getFragment2().codeRange()),
+                            true
+                    )
+            );
+        } else {
+            ref.getSubExpressionMappings().forEach(leafMapping ->
+                    info.addMarking(
+                            createCodeRangeFromJava(leafMapping.getFragment1().codeRange()),
+                            createCodeRangeFromJava(leafMapping.getFragment2().codeRange()),
+                            true
+                    )
+            );
+        }
 
         return info.setGroup(Group.VARIABLE)
                 .setNameBefore(calculateSignatureForVariableDeclarationContainer(ref.getOperationBefore()))


### PR DESCRIPTION
Used `subExpressionMappings` instead of `references`

* In 723ab1cf (Arend) commit: 
Before:
<img width="1311" alt="Screenshot 2023-03-20 at 13 28 08" src="https://user-images.githubusercontent.com/57748412/226341469-8aa2649b-45ca-4dca-b959-e2f771aa5874.png">
After:
<img width="1402" alt="Screenshot 2023-03-20 at 13 26 28" src="https://user-images.githubusercontent.com/57748412/226341487-981d951e-6689-401b-8a30-8073b78a12cc.png">

* In 25265e6a commit `subExpressionMappings` is empty

* In 7beee3d5 commit `subExpressionMappings` and `references` are empty, so the diff window doesn't open

