### PR TITLE
Updated Three Side visualisation 

### DIFF
--- a/common/src/main/java/org/jetbrains/research/refactorinsight/data/RefactoringLine.java
+++ b/common/src/main/java/org/jetbrains/research/refactorinsight/data/RefactoringLine.java
@@ -143,22 +143,19 @@ public class RefactoringLine {
 
         if (hasColumns) {
             try {
-                int leftStartOffset = Utils.getOffset(leftText, lines[LEFT_START] + 1, 1);
                 left.add(new TextRange(
-                        Utils.getOffset(leftText, lines[LEFT_START] + 1, columns[LEFT_START]) - leftStartOffset,
-                        Utils.getOffset(leftText, lines[LEFT_END], columns[LEFT_END]) - leftStartOffset
+                        Utils.getOffset(leftText, lines[LEFT_START] + 1, columns[LEFT_START]),
+                        Utils.getOffset(leftText, lines[LEFT_END], columns[LEFT_END])
                 ));
-                int midStartOffset = Utils.getOffset(midText, lines[MID_START] + 1, 1);
                 mid.add(new TextRange(
-                        Utils.getOffset(midText, lines[MID_START] + 1, columns[MID_START]) - midStartOffset,
-                        Utils.getOffset(midText, lines[MID_END], columns[MID_END]) - midStartOffset
+                        Utils.getOffset(midText, lines[MID_START] + 1, columns[MID_START]),
+                        Utils.getOffset(midText, lines[MID_END], columns[MID_END])
                 ));
-                int rightStartOffset = Utils.getOffset(rightText, lines[RIGHT_START] + 1, 1);
                 right.add(new TextRange(
                         Utils.getOffset(rightText, lines[RIGHT_START] + 1,
-                                columns[RIGHT_START]) - rightStartOffset,
+                                columns[RIGHT_START]),
                         Utils.getOffset(rightText, lines[RIGHT_END],
-                                columns[RIGHT_END]) - rightStartOffset
+                                columns[RIGHT_END])
                 ));
             } catch (Exception e) {
                 e.printStackTrace();

--- a/common/src/main/java/org/jetbrains/research/refactorinsight/diff/ThreeSidedRange.java
+++ b/common/src/main/java/org/jetbrains/research/refactorinsight/diff/ThreeSidedRange.java
@@ -48,6 +48,18 @@ public class ThreeSidedRange {
         this.type = type;
     }
 
+    public TextRange getLeft() {
+        return left.get(0);
+    }
+
+    public TextRange getMid() {
+        return mid.get(0);
+    }
+
+    public TextRange getRight() {
+        return right.get(0);
+    }
+
     private static List<TextRange> deStringify(String value) {
         String regex = delimiter(RANGE, true);
         String[] tokens = value.split(regex);

--- a/java-impl/src/main/java/org/jetbrains/research/refactorinsight/data/classes/ExtractClassJavaHandler.java
+++ b/java-impl/src/main/java/org/jetbrains/research/refactorinsight/data/classes/ExtractClassJavaHandler.java
@@ -1,14 +1,11 @@
 package org.jetbrains.research.refactorinsight.data.classes;
 
 import gr.uom.java.xmi.diff.ExtractClassRefactoring;
-import org.jetbrains.research.refactorinsight.data.Group;
-import org.jetbrains.research.refactorinsight.data.JavaRefactoringHandler;
-import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
-import org.jetbrains.research.refactorinsight.data.RefactoringLine;
-import org.jetbrains.research.refactorinsight.diff.VisualizationType;
+import org.jetbrains.research.refactorinsight.data.*;
 import org.refactoringminer.api.Refactoring;
 
 import static org.jetbrains.research.refactorinsight.data.util.JavaUtils.createCodeRangeFromJava;
+import static org.jetbrains.research.refactorinsight.data.util.JavaUtils.createLocationInfoFromJava;
 
 public class ExtractClassJavaHandler extends JavaRefactoringHandler {
 
@@ -25,59 +22,53 @@ public class ExtractClassJavaHandler extends JavaRefactoringHandler {
             info.setGroup(Group.CLASS);
         }
 
-        info.setDetailsBefore(ref.getOriginalClass().getPackageName())
-                .setDetailsAfter(ref.getExtractedClass().getPackageName())
+        info.setDetailsBefore(ref.getOriginalClass().getName())
+                .setDetailsAfter(ref.getExtractedClass().getName())
                 .setElementBefore(ref.getOriginalClass().getName())
                 .setElementAfter(ref.getExtractedClass().getName())
                 .setNameBefore(ref.getExtractedClass().getName())
                 .setNameAfter(ref.getExtractedClass().getName());
 
-        if (ref.getAttributeOfExtractedClassTypeInOriginalClass() != null) {
-            info.setThreeSided(true);
-            ref.getExtractedOperations().keySet().forEach(operation -> info.addMarking(
-                    createCodeRangeFromJava(operation.codeRange()),
-                    createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
-                    createCodeRangeFromJava(ref.getAttributeOfExtractedClassTypeInOriginalClass().codeRange()),
-                    VisualizationType.LEFT,
-                    null,
-                    RefactoringLine.MarkingOption.NONE,
-                    true));
 
-            ref.getExtractedAttributes().keySet().forEach(operation -> info.addMarking(
-                    createCodeRangeFromJava(operation.codeRange()),
-                    createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
-                    createCodeRangeFromJava(ref.getAttributeOfExtractedClassTypeInOriginalClass().codeRange()),
-                    VisualizationType.LEFT,
-                    null,
-                    RefactoringLine.MarkingOption.NONE,
-                    true));
+        ref.getExtractedAttributes().keySet().forEach(attribute -> info.addMarking(
+                createCodeRangeFromJava(attribute.codeRange()),
+                createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
+                line -> line
+                        .addOffset(
+                                createLocationInfoFromJava(attribute.getLocationInfo()),
+                                RefactoringLine.MarkingOption.REMOVE),
+                RefactoringLine.MarkingOption.REMOVE,
+                false));
 
+        ref.getExtractedAttributes().values().forEach(attribute -> info.addMarking(
+                createCodeRangeFromJava(ref.getOriginalClass().codeRange()),
+                createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
+                line -> line
+                        .addOffset(
+                                createLocationInfoFromJava(attribute.getLocationInfo()),
+                                RefactoringLine.MarkingOption.ADD),
+                RefactoringLine.MarkingOption.ADD,
+                false));
 
-            String[] nameSpace = ref.getExtractedClass().getName().split("\\.");
-            String className = nameSpace[nameSpace.length - 1];
+        ref.getExtractedOperations().keySet().forEach(operation -> info.addMarking(
+                createCodeRangeFromJava(operation.codeRange()),
+                createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
+                line -> line
+                        .addOffset(
+                                createLocationInfoFromJava(operation.getLocationInfo()),
+                                RefactoringLine.MarkingOption.REMOVE),
+                RefactoringLine.MarkingOption.REMOVE,
+                false));
 
-            info.addMarking(
-                    createCodeRangeFromJava(ref.getOriginalClass().codeRange()),
-                    createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
-                    createCodeRangeFromJava(ref.getAttributeOfExtractedClassTypeInOriginalClass().codeRange()),
-
-                    VisualizationType.RIGHT,
-                    refactoringLine -> refactoringLine.setWord(new String[]{
-                            null,
-                            className,
-                            null
-                    }),
-                    RefactoringLine.MarkingOption.EXTRACT,
-                    true);
-        } else {
-            ref.getExtractedOperations().keySet().forEach(operation -> info.addMarking(
-                    createCodeRangeFromJava(operation.codeRange()),
-                    createCodeRangeFromJava(ref.getExtractedClass().codeRange()), true));
-
-            ref.getExtractedAttributes().keySet().forEach(operation -> info.addMarking(
-                    createCodeRangeFromJava(operation.codeRange()),
-                    createCodeRangeFromJava(ref.getExtractedClass().codeRange()), true));
-        }
+        ref.getExtractedOperations().values().forEach(operation -> info.addMarking(
+                createCodeRangeFromJava(ref.getOriginalClass().codeRange()),
+                createCodeRangeFromJava(ref.getExtractedClass().codeRange()),
+                line -> line
+                        .addOffset(
+                                createLocationInfoFromJava(operation.getLocationInfo()),
+                                RefactoringLine.MarkingOption.ADD),
+                RefactoringLine.MarkingOption.ADD,
+                false));
         return info;
     }
 

--- a/java-impl/src/main/java/org/jetbrains/research/refactorinsight/data/classes/ExtractClassJavaHandler.java
+++ b/java-impl/src/main/java/org/jetbrains/research/refactorinsight/data/classes/ExtractClassJavaHandler.java
@@ -29,6 +29,7 @@ public class ExtractClassJavaHandler extends JavaRefactoringHandler {
                 .setNameBefore(ref.getExtractedClass().getName())
                 .setNameAfter(ref.getExtractedClass().getName());
 
+        info.setFoldingDescriptorAfter(FoldingBuilder.fromClass(ref.getExtractedClass()));
 
         ref.getExtractedAttributes().keySet().forEach(attribute -> info.addMarking(
                 createCodeRangeFromJava(attribute.codeRange()),

--- a/plugin/src/main/java/org/jetbrains/research/refactorinsight/folding/RefactoringFolder.java
+++ b/plugin/src/main/java/org/jetbrains/research/refactorinsight/folding/RefactoringFolder.java
@@ -56,6 +56,9 @@ public class RefactoringFolder {
     FoldingHandler moveClassHandler = new MoveClassFoldingHandler();
     foldingHandlers.put(RefactoringType.MOVE_CLASS.getName(), moveClassHandler);
     foldingHandlers.put(RefactoringType.MOVE_RENAME_CLASS.getName(), moveClassHandler);
+    FoldingHandler extractClassHandler = new ExtractClassFoldingHandler();
+    foldingHandlers.put(RefactoringType.EXTRACT_CLASS.getName(), extractClassHandler);
+    foldingHandlers.put(RefactoringType.EXTRACT_SUBCLASS.getName(), extractClassHandler);
     foldRegions = new HashSet<>();
   }
 

--- a/plugin/src/main/java/org/jetbrains/research/refactorinsight/folding/handlers/ExtractClassFoldingHandler.java
+++ b/plugin/src/main/java/org/jetbrains/research/refactorinsight/folding/handlers/ExtractClassFoldingHandler.java
@@ -1,0 +1,50 @@
+package org.jetbrains.research.refactorinsight.folding.handlers;
+
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.research.refactorinsight.data.RefactoringInfo;
+import org.jetbrains.research.refactorinsight.folding.FoldingDescriptor;
+import org.jetbrains.research.refactorinsight.utils.TextUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ExtractClassFoldingHandler implements FoldingHandler {
+    @Override
+    public @NotNull List<FoldingDescriptor> getFolds(@NotNull RefactoringInfo info, @NotNull PsiFile file, boolean isBefore) {
+        String path = isBefore ? info.getLeftPath() : info.getRightPath();
+        if (isBefore || !file.getVirtualFile().getPath().endsWith(path)) {
+            return Collections.emptyList();
+        }
+        FoldingDescriptor descriptor = info.getFoldingDescriptorAfter();
+        if (!descriptor.hasHintText()) {
+            String details = TextUtils.skipPackages(info.getDetailsBefore());
+            String hintText = "Extracted from " + details;
+            descriptor.addHintText(hintText);
+        }
+        return Collections.singletonList(descriptor);
+    }
+
+    @Override
+    public @NotNull FoldingDescriptor uniteFolds(@NotNull List<FoldingDescriptor> folds) {
+        FoldingDescriptor descriptor = folds.get(0);
+        if (!descriptor.isHintTextUnited()) {
+            String hintText = "Extracted from ";
+            List<String> hints = folds.stream().map(FoldingDescriptor::getHintText).collect(Collectors.toList());
+            hints = hints.stream().map(hint -> hint.substring("Extracted from ".length())).collect(Collectors.toList());
+
+            if (hints.size() < 4) {
+                hintText += String.join(", ", hints) + " classes";
+            } else {
+                hintText += hints.size() + " classes";
+            }
+            descriptor.addHintText(hintText);
+
+            String finalHintText = hintText;
+            folds.forEach(eachDescriptor -> eachDescriptor.addUnitedHintText(finalHintText));
+        }
+
+        return descriptor;
+    }
+}


### PR DESCRIPTION
#131 

Unnecessary highlighting between the windows remains. 

<img width="1367" alt="Screenshot 2023-03-31 at 03 12 13" src="https://user-images.githubusercontent.com/57748412/228998912-dd959764-12fc-4e47-a720-c40e14a85e2c.png">

In the case of Two Side and More Side, we have a `SimpleDiffViewer` that has a `SimpleTextDiffProvider` that has a `compareRange` function that takes a `DiffComputer diffComputer` that determines the changes to be highlighted. If `diffComputer == null`, the `SimpleTextDiffProvider` finds the changes itself. 

In the case of Three Side, we have `SimpleThreesideDiffViewer`, which has a `SimpleThreesideTextDiffProvider`, which hasn't function that takes something to override the changes somehow.  That's why `SimpleThreesideTextDiffProvider` always finds the changes that need to be highlighted by itself. 

Currently `SimpleThreesideDiffViewer.getChanges()` returns `unmodifiableList`, so nothing can be changed here. 